### PR TITLE
fix: use grafana k6 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-# renovate: datasource=docker depName=loadimpact/k6 versioning=docker
+# renovate: datasource=docker depName=grafana/k6 versioning=docker
 ARG K6_VERSION=0.47.0
 
 #################################################
@@ -114,7 +114,7 @@ RUN make K6_VERSION=$K6_VERSION build
 # "Update" the k6 official image
 #################################################
 
-FROM loadimpact/k6:$K6_VERSION AS k6
+FROM grafana/k6:$K6_VERSION AS k6
 ARG K6_VERSION=$K6_VERSION
 ARG VERSION=$VERSION
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# renovate: datasource=docker depName=loadimpact/k6 versioning=docker
+# renovate: datasource=docker depName=grafana/k6 versioning=docker
 export K6_VERSION=0.47.0
 export K6_LOCATION?=$(GOPATH)/bin/k6
 REPO=github.com/leonyork/xk6-output-timestream


### PR DESCRIPTION
Fixes the failure in https://github.com/leonyork/xk6-output-timestream/actions/runs/6473626203 as the arm64 images are only pushed to the new grafana dockerhub image.