### PR TITLE
refactor: fix linting warnings

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,18 +2,20 @@ package timestream
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/kelseyhightower/envconfig"
 )
 
 type Config struct {
-	Region       string `json:"region"       envconfig:"K6_TIMESTREAM_REGION"`
-	DatabaseName string `json:"databaseName" envconfig:"K6_TIMESTREAM_DATABASE_NAME"`
-	TableName    string `json:"tableName"    envconfig:"K6_TIMESTREAM_TABLE_NAME"`
+	Region       string `envconfig:"K6_TIMESTREAM_REGION"        json:"region"`
+	DatabaseName string `envconfig:"K6_TIMESTREAM_DATABASE_NAME" json:"databaseName"`
+	TableName    string `envconfig:"K6_TIMESTREAM_TABLE_NAME"    json:"tableName"`
 }
 
 func NewConfig() Config {
 	c := Config{}
+
 	return c
 }
 
@@ -21,38 +23,49 @@ func (c Config) apply(cfg Config) Config {
 	if len(cfg.Region) > 0 {
 		c.Region = cfg.Region
 	}
+
 	if len(cfg.DatabaseName) > 0 {
 		c.DatabaseName = cfg.DatabaseName
 	}
+
 	if len(cfg.TableName) > 0 {
 		c.TableName = cfg.TableName
 	}
+
 	return c
 }
 
 func parseJSON(data json.RawMessage) (Config, error) {
 	conf := Config{}
-	err := json.Unmarshal(data, &conf)
-	return conf, err
+	if err := json.Unmarshal(data, &conf); err != nil {
+		return conf, fmt.Errorf("unable to parse json: %w", err)
+	}
+
+	return conf, nil
 }
 
 // GetConsolidatedConfig combines {default config values + JSON config +
 // environment vars config values}, and returns the final result.
 func GetConsolidatedConfig(
-	jsonRawConf json.RawMessage) (Config, error) {
+	jsonRawConf json.RawMessage,
+) (Config, error) {
 	result := NewConfig()
+
 	if jsonRawConf != nil {
 		jsonConf, err := parseJSON(jsonRawConf)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("unable to parse json config: %w", err)
 		}
+
 		result = result.apply(jsonConf)
 	}
 
 	envConfig := Config{}
 	if err := envconfig.Process("", &envConfig); err != nil {
-		return result, err
+		return result, fmt.Errorf("unable to parse env config: %w", err)
 	}
+
 	result = result.apply(envConfig)
+
 	return result, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -4,26 +4,27 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewConfig(t *testing.T) {
 	t.Parallel()
+
 	config := NewConfig()
 
 	t.Run("The Region is empty", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "", config.Region)
+		require.Equal(t, "", config.Region)
 	})
 
 	t.Run("The DatabaseName is empty", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "", config.DatabaseName)
+		require.Equal(t, "", config.DatabaseName)
 	})
 
 	t.Run("The TableName is empty", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "", config.TableName)
+		require.Equal(t, "", config.TableName)
 	})
 }
 
@@ -31,46 +32,53 @@ func TestGetConsolidatedConfig(t *testing.T) {
 	os.Clearenv()
 
 	t.Run("Defaults applied correctly", func(t *testing.T) {
+		t.Parallel()
 		config, err := GetConsolidatedConfig([]byte("{}"))
-		assert.NoError(t, err)
-		assert.Equal(t, "", config.Region)
-		assert.Equal(t, "", config.DatabaseName)
-		assert.Equal(t, "", config.TableName)
+		require.NoError(t, err)
+		require.Equal(t, "", config.Region)
+		require.Equal(t, "", config.DatabaseName)
+		require.Equal(t, "", config.TableName)
 	})
 
-	testJson := []byte(
+	testJSON := []byte(
 		`{"region": "us-east-1", "databaseName": "testDbJson", "tableName": "testTableJson", "pushInterval": "30s"}`,
 	)
 
 	t.Run("JSON is applied correctly", func(t *testing.T) {
-		config, err := GetConsolidatedConfig(testJson)
-		assert.NoError(t, err)
-		assert.Equal(t, "us-east-1", config.Region)
-		assert.Equal(t, "testDbJson", config.DatabaseName)
-		assert.Equal(t, "testTableJson", config.TableName)
+		t.Parallel()
+		config, err := GetConsolidatedConfig(testJSON)
+		require.NoError(t, err)
+		require.Equal(t, "us-east-1", config.Region)
+		require.Equal(t, "testDbJson", config.DatabaseName)
+		require.Equal(t, "testTableJson", config.TableName)
 	})
 
-	os.Setenv("K6_TIMESTREAM_REGION", "eu-west-1")
-	os.Setenv("K6_TIMESTREAM_DATABASE_NAME", "testDbEnv")
-	os.Setenv("K6_TIMESTREAM_TABLE_NAME", "testTableEnv")
-	os.Setenv("K6_TIMESTREAM_PUSH_INTERVAL", "1h")
-
 	t.Run("Env variables applied correctly", func(t *testing.T) {
+		t.Setenv("K6_TIMESTREAM_REGION", "eu-west-1")
+		t.Setenv("K6_TIMESTREAM_DATABASE_NAME", "testDbEnv")
+		t.Setenv("K6_TIMESTREAM_TABLE_NAME", "testTableEnv")
+		t.Setenv("K6_TIMESTREAM_PUSH_INTERVAL", "1h")
+
 		config, err := GetConsolidatedConfig([]byte("{}"))
-		assert.NoError(t, err)
-		assert.Equal(t, "eu-west-1", config.Region)
-		assert.Equal(t, "testDbEnv", config.DatabaseName)
-		assert.Equal(t, "testTableEnv", config.TableName)
+		require.NoError(t, err)
+		require.Equal(t, "eu-west-1", config.Region)
+		require.Equal(t, "testDbEnv", config.DatabaseName)
+		require.Equal(t, "testTableEnv", config.TableName)
 	})
 
 	t.Run(
 		"Env variables applied correctly over json variables",
 		func(t *testing.T) {
-			config, err := GetConsolidatedConfig(testJson)
-			assert.NoError(t, err)
-			assert.Equal(t, "eu-west-1", config.Region)
-			assert.Equal(t, "testDbEnv", config.DatabaseName)
-			assert.Equal(t, "testTableEnv", config.TableName)
+			t.Setenv("K6_TIMESTREAM_REGION", "eu-west-1")
+			t.Setenv("K6_TIMESTREAM_DATABASE_NAME", "testDbEnv")
+			t.Setenv("K6_TIMESTREAM_TABLE_NAME", "testTableEnv")
+			t.Setenv("K6_TIMESTREAM_PUSH_INTERVAL", "1h")
+
+			config, err := GetConsolidatedConfig(testJSON)
+			require.NoError(t, err)
+			require.Equal(t, "eu-west-1", config.Region)
+			require.Equal(t, "testDbEnv", config.DatabaseName)
+			require.Equal(t, "testTableEnv", config.TableName)
 		},
 	)
 }


### PR DESCRIPTION
Fix errors found by turning on a number of golangci-lint's linters. This is with all linters enabled except:

- deadcode
- exhaustivestruct
- golint
- ifshort
- interfacer
- maligned
- nosnakecase
- scopelint
- structcheck
- varcheck
- depguard
- gci
- musttag
- gomodguard

Errors mostly fixed, ignoring test files.