### PR TITLE
Fix incorrect charset in devcontainer

### DIFF
--- a/.devcontainer/tools.default.sh
+++ b/.devcontainer/tools.default.sh
@@ -51,6 +51,8 @@ go install github.com/cweill/gotests/gotests@latest
 go install mvdan.cc/gofumpt@latest
 
 cp -f .devcontainer/.zshrc $HOME
+# See https://superuser.com/questions/1499698/ssh-login-causes-repeating-characters-in-my-zsh
+echo "export LC_ALL=C.UTF-8" >>~/.zshrc
 
 # Required by vscode extension golang.go
 go install golang.org/x/tools/gopls@latest


### PR DESCRIPTION
Stops repeating characters in devcontainer - see https://superuser.com/questions/1499698/ssh-login-causes-repeating-characters-in-my-zsh