### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,9 +5,13 @@ on:
       - main
     paths-ignore:
       - "**.md"
-  workflow_dispatch:
-  schedule:
-    - cron: "0 19 * * *"
+  pull_request_target:
+    types:
+      - labeled
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
 
 permissions:
   contents: read
@@ -18,6 +22,7 @@ env:
 
 jobs:
   test:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event.label.name == 'approved' }}
     runs-on: ubuntu-22.04
     environment: Test
     steps:

--- a/.github/workflows/build-test-tag.yaml
+++ b/.github/workflows/build-test-tag.yaml
@@ -30,6 +30,7 @@ jobs:
             docker login --username ${{ github.repository_owner }} --password ${{ github.token }} ghcr.io
             && make build-image push-image
         env:
+          K6_DIST_LOCATION: k6-${{ matrix.arch }}
           FULL_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/k6:${{ github.sha }}-${{ matrix.arch }}
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
@@ -37,7 +38,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: k6-${{ matrix.arch }}
-          path: ./dist/k6
+          path: ./k6-${{ matrix.arch }}
 
   build-multiarch-docker-manifest:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
- Incorrectly named executables meant that releases were failing
- Forks do not have access to the secret needed for running integration tests