### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-grafana.yaml
+++ b/.github/workflows/build-grafana.yaml
@@ -1,4 +1,6 @@
 name: Build Grafana
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/leonyork/xk6-output-timestream/security/code-scanning/1](https://github.com/leonyork/xk6-output-timestream/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the specific permissions required are not detailed in the provided code, we will start with the most restrictive permissions (`contents: read`) and adjust as necessary based on the actual needs of the `_build-grafana.yaml` workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
