### PR TITLE
ci: devcontainer fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,8 +17,13 @@
     // Allows us to install applications in a known location so they can be referenced by
     // vscode settings (e.g. shfmt)
     "install-direnv": "nix profile install . && direnv allow && echo 'eval \"$(direnv hook bash)\"' >> ~/.bashrc && echo 'eval \"$(direnv hook zsh)\"' >> ~/.zshrc",
-    // Check that build of the dev env works
-    "build-dev-env": "nix print-dev-env > /dev/null"
+    // Check/cache the dev env
+    "build-dev-env": "nix print-dev-env > /dev/null",
+    "link-zsh-history-volume": "sudo chown vscode:vscode /home/vscode/.hist && touch /home/vscode/.hist/.zsh_history && ln -nsf /home/vscode/.hist/.zsh_history ~/.zsh_history",
+    "link-bash-history-volume": "sudo chown vscode:vscode /home/vscode/.hist && touch /home/vscode/.hist/.bash_history && ln -nsf /home/vscode/.hist/.bash_history ~/.bash_history",
+    // Allows the container to update the aws directory (just not the config)
+    // For codespaces, the .aws directory isn't mounted, so we create it
+    "setup-aws-config": "sudo mkdir -p /home/vscode/.aws && sudo chown vscode:vscode /home/vscode/.aws && if [ -f '/home/vscode/.aws/host-config' ]; then sh -c 'cat /home/vscode/.aws/host-config | tee /home/vscode/.aws/config >/dev/null'; fi"
   },
 
   "containerEnv": {
@@ -73,5 +78,10 @@
         "vivaxy.vscode-conventional-commits"
       ]
     }
-  }
+  },
+
+  "mounts": [
+    "source=xk6-output-timestream_hist,target=/home/vscode/.hist,type=volume",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/config,target=/home/vscode/.aws/host-config,type=bind,readonly,consistency=cached"
+  ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,10 @@
 
   // See https://github.com/NixOS/nix/issues/6680#issuecomment-1577781769
   "onCreateCommand": {
+    // Allows us to install applications in a known location so they can be referenced by
+    // vscode settings (e.g. shfmt)
     "install-direnv": "nix profile install . && direnv allow && echo 'eval \"$(direnv hook bash)\"' >> ~/.bashrc && echo 'eval \"$(direnv hook zsh)\"' >> ~/.zshrc",
+    // Check that build of the dev env works
     "build-dev-env": "nix print-dev-env > /dev/null"
   },
 
@@ -29,12 +32,9 @@
     "vscode": {
       "settings": {
         "go.testOnSave": true,
-        "go.alternateTools": {
-          "go": "/root/.nix-profile/bin/go"
-        },
         "editor.codeActionsOnSave": {
-          "source.fixAll": true,
-          "source.organizeImports": true
+          "source.fixAll": "always",
+          "source.organizeImports": "always"
         },
         "[go]": {
           "editor.defaultFormatter": "golang.go"
@@ -56,25 +56,22 @@
         },
         "go.lintTool": "golangci-lint",
         "go.lintFlags": ["--fast"],
-        "shellformat.path": "/root/.nix-profile/bin/shfmt",
+        "shellformat.path": "/home/vscode/.nix-profile/bin/shfmt",
         "shellformat.flag": "--binary-next-line",
-        "direnv.path.executable": "/root/.nix-profile/bin/direnv",
-        "editor.formatOnSave": true,
-        "terminal.integrated.defaultProfile.linux": "zsh"
+        "editor.formatOnSave": true
       },
-      "remote.localPortHost": "allInterfaces"
-    },
-
-    "extensions": [
-      "golang.go",
-      "esbenp.prettier-vscode",
-      "foxundermoon.shell-format",
-      "exiasr.hadolint",
-      "jnoortheen.nix-ide",
-      "mkhl.direnv",
-      "ms-azuretools.vscode-containers",
-      "DavidAnson.vscode-markdownlint",
-      "vivaxy.vscode-conventional-commits"
-    ]
+      "remote.localPortHost": "allInterfaces",
+      "extensions": [
+        "golang.go",
+        "esbenp.prettier-vscode",
+        "foxundermoon.shell-format",
+        "exiasr.hadolint",
+        "jnoortheen.nix-ide",
+        "mkhl.direnv",
+        "ms-azuretools.vscode-containers",
+        "DavidAnson.vscode-markdownlint",
+        "vivaxy.vscode-conventional-commits"
+      ]
+    }
   }
 }


### PR DESCRIPTION
- Only reference shfmt bin path directly from devcontainer settings as it is the only one that doesn't seem to use $PATH
- Update deprecated values for codeActionsOnSave
- Move extensions to the correct locations under customizations.vscode

Adds back in the functionality to:
- Take the aws config from the host
- Store the bash & zsh history in a volume