### PR TITLE
ci: remove renovate from dev tooling

### DIFF
--- a/dependencies.nix
+++ b/dependencies.nix
@@ -16,7 +16,6 @@ with pkgs;
   nodePackages.prettier
   nodePackages.markdownlint-cli2
   pre-commit
-  renovate
   shfmt
   statix
   xk6


### PR DESCRIPTION
Remove Renovate as it isn't used locally or in CI and instead runs as a Github App.